### PR TITLE
Satupili/trace unet

### DIFF
--- a/nerf/trace_unet.py
+++ b/nerf/trace_unet.py
@@ -1,0 +1,89 @@
+import time
+import torch
+from diffusers import UNet2DConditionModel
+import functools
+from dataclasses import dataclass
+
+# torch disable grad
+torch.set_grad_enabled(False)
+
+# set variables
+n_experiments = 2
+runs_per_experiment = 50
+
+# example inputs
+sample = torch.randn(2, 4, 64, 64).cuda()
+timestep = torch.rand(1).cuda() * 999
+encoder_hidden_states = torch.randn(2, 77, 768).cuda()
+inputs = (sample, timestep, encoder_hidden_states)
+
+unet = UNet2DConditionModel.from_pretrained("runwayml/stable-diffusion-v1-5", subfolder="unet", use_auth_token=True).to("cuda")
+unet.eval()
+unet.to(memory_format=torch.channels_last)  # use channels_last memory format
+unet.forward = functools.partial(unet.forward, return_dict=False)  # set return_dict=False as default
+
+# warmup
+for _ in range(3):
+     with torch.inference_mode():
+        orig_output = unet(*inputs)
+
+# trace
+print("tracing..")
+unet_traced = torch.jit.trace(unet, inputs)
+unet_traced.eval()
+print("done tracing")
+
+# warmup and optimize graph
+for _ in range(5):
+    with torch.inference_mode():
+        #inputs = generate_inputs()
+        orig_output = unet_traced(*inputs)
+
+# benchmarking
+with torch.inference_mode():
+    for _ in range(n_experiments):
+        torch.cuda.synchronize()
+        start_time = time.time()
+        for _ in range(runs_per_experiment):
+            orig_output = unet_traced(*inputs)
+        torch.cuda.synchronize()
+        print(f"unet traced inference took {time.time() - start_time:.2f} seconds")
+    for _ in range(n_experiments):
+        torch.cuda.synchronize()
+        start_time = time.time()
+        for _ in range(runs_per_experiment):
+            orig_output = unet(*inputs)
+        torch.cuda.synchronize()
+        print(f"unet inference took {time.time() - start_time:.2f} seconds")
+
+# save the model
+unet_traced.save("unet_traced.pt")
+
+@dataclass
+class UNet2DConditionOutput:
+    sample: torch.FloatTensor
+
+class TracedUNet(torch.nn.Module):
+    def __init__(self, device, token):
+        super().__init__()
+        self.device = device
+        self.token = token
+        self.unet = UNet2DConditionModel.from_pretrained("runwayml/stable-diffusion-v1-5", subfolder="unet", use_auth_token=self.token).to(self.device)
+        self.in_channels = self.unet.in_channels
+        self.unet_traced = torch.jit.load("unet_traced.pt")
+
+    def forward(self, latent_model_input, t, encoder_hidden_states):
+        sample = self.unet_traced(latent_model_input, t, encoder_hidden_states)[0]
+        return UNet2DConditionOutput(sample=sample)
+
+traced_loaded_unet = TracedUNet("cuda", True).to("cuda")
+
+# benchmarking
+with torch.inference_mode():
+    for _ in range(2*n_experiments):
+        torch.cuda.synchronize()
+        start_time = time.time()
+        for _ in range(runs_per_experiment):
+            orig_output = traced_loaded_unet(*inputs)
+        torch.cuda.synchronize()
+        print(f"unet loaded traced inference took {time.time() - start_time:.2f} seconds")

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -27,6 +27,8 @@ import trimesh
 from rich.console import Console
 from torch_ema import ExponentialMovingAverage
 
+from torch.profiler import profile, record_function, ProfilerActivity, tensorboard_trace_handler
+
 from packaging import version as pver
 
 def custom_meshgrid(*args):
@@ -376,6 +378,10 @@ class Trainer(object):
         
         # encode pred_rgb to latents
         # _t = time.time()
+        # with profile(activities=[
+        #     ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True, profile_memory=True, use_cuda=True, on_trace_ready=tensorboard_trace_handler("/home/satupili/stable-dreamfusion/"+str(_t)), with_stack=True) as prof:
+        #     loss = self.guidance.train_step(text_z, pred_rgb)
+        # prof.step()
         loss = self.guidance.train_step(text_z, pred_rgb)
         # torch.cuda.synchronize(); print(f'[TIME] total guiding {time.time() - _t:.4f}s')
 


### PR DESCRIPTION
Changes:
- added a python file that can be run to create the traced unet (this file must be run before running the stable dreamfusion code because unet_traced.pt was too large to upload)
- made changes to sd.py so that the traced unet is used

The traces below show that the traced unet takes approximately 90 ms while the actual unet takes around 99 ms. Since there is a 10% improvemnet in performance, it is beneficial to use the traced unet. During the second step however, the traced unet takes particularily long and takes around 20 seconds. When we use torch.jit.trace to save the pt model and then load it to run, the second run is slow because in the first run, the graph is being profiled, and in the second run, it's being optimized. 

![traced_unet](https://user-images.githubusercontent.com/29380503/207494131-f12ba6ee-f43d-4a84-9c4e-b3831c81f3b6.png)
![unet](https://user-images.githubusercontent.com/29380503/207494133-34b80903-6108-4cc0-ad59-40da67987aa1.png)

@claforte @harishanand95 
